### PR TITLE
Update World Cup 2026 match id for finals

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -68,10 +68,10 @@ Wed Jul 15
 
 ▪ Match for third place   
 Sat Jul 18 
-  17:00 UTC-4    L101 v L102    @ Miami (Miami Gardens)
+  (103) 17:00 UTC-4    L101 v L102    @ Miami (Miami Gardens)
 
 ▪ Final
 Sun Jul 19 
-  15:00 UTC-4    W101 v W102    @ New York/New Jersey (East Rutherford)
+  (104) 15:00 UTC-4    W101 v W102    @ New York/New Jersey (East Rutherford)
 
 


### PR DESCRIPTION
last two matches didn't have an id. Observed this in worldcup.json