### PR TITLE
Update of NOTES.MD with questions

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -62,9 +62,9 @@ Quarter-finals replays
 
 Official site - [`www.fifa.com/worldcup`](http://www.fifa.com/worldcup)
 
-- 32 teams
-- 64 matches
-- every four years (next in 2014 in Brazil and 2018 in Russia)
+- 32 teams (48 in 2026 USA/Canada/Mexico)
+- 64 matches (104 in 2026 USA/Canada/Mexico)
+- every four years
 
 
 World Cup 2014 Brazil

--- a/NOTES.md
+++ b/NOTES.md
@@ -62,8 +62,8 @@ Quarter-finals replays
 
 Official site - [`www.fifa.com/worldcup`](http://www.fifa.com/worldcup)
 
-- 32 teams (48 in 2026 USA/Canada/Mexico)
-- 64 matches (104 in 2026 USA/Canada/Mexico)
+- 32 teams (48 in 2026 @ Canada, USA, and Mexico)
+- 64 matches (104 in 2026 @ Canada, USA, and Mexico)
 - every four years
 
 
@@ -79,12 +79,14 @@ World Cup 2010 South Africa
 
 ### Wikipedia
 
+- [2022 FIFA World Cup](https://en.wikipedia.org/wiki/2022_FIFA_World_Cup)
 - [2018 FIFA World Cup](http://en.wikipedia.org/wiki/2018_FIFA_World_Cup)
 - [2014 FIFA World Cup](http://en.wikipedia.org/wiki/2014_FIFA_World_Cup)
 - [2010 FIFA World Cup](http://en.wikipedia.org/wiki/2010_FIFA_World_Cup)
 
 ### Wikipedia (de)
 
+- [Fußball-Weltmeisterschaft 2022 (de)](https://de.wikipedia.org/wiki/Fußball-Weltmeisterschaft_2022)
 - [Fußball-Weltmeisterschaft 2018 (de)](http://de.wikipedia.org/wiki/Fußball-Weltmeisterschaft_2018)
 - [Fußball-Weltmeisterschaft 2014 (de)](http://de.wikipedia.org/wiki/Fußball-Weltmeisterschaft_2014)
 - [Fußball-Weltmeisterschaft 2010 (de)](http://de.wikipedia.org/wiki/Fußball-Weltmeisterschaft_2010)


### PR DESCRIPTION
**Link to Wiki for 2022 and details with exceptions for 2026.**

### Questions:

- in README.md the scores are shown after the teams, while in 2022--Qatar the scores have replaced the v-sign between the teams. Can we do both when contributing with update of results or should we prefer location between the teams?

- all scores show as cumulated score ht/rt/et/ but penalties just shows the penalty score. For these cases there is no direct read of the total score and one would need to add e.t. score plus penalties. Can this be changed going forward or does it need to stay like this for any reason?
