### PR TITLE
Update cup.txt - Mexico v SA

### DIFF
--- a/2026--usa/cup.txt
+++ b/2026--usa/cup.txt
@@ -76,7 +76,8 @@ Group L | England    Croatia     Ghana   Panama
 
 ▪ Group A
 Thu June 11
-  13:00 UTC-6     Mexico       v South Africa        @ Mexico City
+  13:00 UTC-6     Mexico  2-0 (1-0)  South Africa        @ Mexico City
+               (Julian Quinones 9' Raul Jimenez 67')
   20:00 UTC-6     South Korea  v Czech Republic     @ Guadalajara (Zapopan)
 Thu June 18
   12:00 UTC-4     Czech Republic    v South Africa   @ Atlanta


### PR DESCRIPTION
Using the format from https://github.com/openfootball/worldcup/blob/master/2022--qatar/cup.txt as a template. 

Presuming format :  

```
Team  fulltime (halftime)  Team 2
      (T1 Scorer1 M' T1 Scorer 2 M' ; T2 Scorer1 M')
```

Notes:
- I had to drop the "v" to meet the format
- I had to drop all accents from names, which seemed to be true in the 2022 txt