### PR TITLE
World Cup 2026: fill in Round of 32 teams for Groups A/B/C

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -11,11 +11,11 @@
 
 ▪ Round of 32
 Sun Jun 28 
-  (73) 12:00 UTC-7  2A v 2B           @ Los Angeles (Inglewood)
+  (73) 12:00 UTC-7  South Africa v Canada   @ Los Angeles (Inglewood)   ## 2A / 2B
 Mon Jun 29
   (74) 16:30 UTC-4  Germany v 3A/B/C/D/F   @ Boston (Foxborough)      ## 1E
-  (75) 19:00 UTC-6  1F v 2C           @ Monterrey (Guadalupe)
-  (76) 12:00 UTC-5  1C v 2F           @ Houston
+  (75) 19:00 UTC-6  1F v Morocco   @ Monterrey (Guadalupe)   ## 2C
+  (76) 12:00 UTC-5  Brazil v 2F   @ Houston   ## 1C
 Tue Jun 30 
   (77) 17:00 UTC-4  1I v 3C/D/F/G/H   @ New York/New Jersey (East Rutherford) 
   (78) 12:00 UTC-5  2E v 2I           @ Dallas (Arlington)
@@ -27,7 +27,7 @@ Wed Jul 1
 Thu Jul 2 
   (83) 19:00 UTC-4  2K v 2L           @ Toronto 
   (84) 12:00 UTC-7  1H v 2J           @ Los Angeles (Inglewood)
-  (85) 20:00 UTC-7  1B v 3E/F/G/I/J   @ Vancouver
+  (85) 20:00 UTC-7  Switzerland v 3E/F/G/I/J   @ Vancouver   ## 1B
 Fri Jul 3 
   (86) 18:00 UTC-4  1J v 2H           @ Miami (Miami Gardens)
   (87) 20:30 UTC-5  1K v 3D/E/I/J/L   @ Kansas City


### PR DESCRIPTION
Groups A, B and C have finished, so this resolves the now-known Round-of-32 participants

- **(73)** `2A v 2B` → **South Africa v Canada**
- **(75)** `2C` → **Morocco**
- **(76)** `1C` → **Brazil**
- **(85)** `1B` → **Switzerland**