### PR TITLE
World Cup 2026: fill in Round-of-32 teams from Groups D, E and F

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -14,11 +14,11 @@ Sun Jun 28
   (73) 12:00 UTC-7  South Africa v Canada   @ Los Angeles (Inglewood)   ## 2A / 2B
 Mon Jun 29
   (74) 16:30 UTC-4  Germany v 3A/B/C/D/F   @ Boston (Foxborough)      ## 1E
-  (75) 19:00 UTC-6  1F v Morocco   @ Monterrey (Guadalupe)   ## 2C
-  (76) 12:00 UTC-5  Brazil v 2F   @ Houston   ## 1C
+  (75) 19:00 UTC-6  Netherlands v Morocco   @ Monterrey (Guadalupe)   ## 1F / 2C
+  (76) 12:00 UTC-5  Brazil v Japan   @ Houston   ## 1C / 2F
 Tue Jun 30 
   (77) 17:00 UTC-4  1I v 3C/D/F/G/H   @ New York/New Jersey (East Rutherford) 
-  (78) 12:00 UTC-5  2E v 2I           @ Dallas (Arlington)
+  (78) 12:00 UTC-5  Ivory Coast v 2I   @ Dallas (Arlington)   ## 2E
   (79) 19:00 UTC-6  Mexico v 3C/E/F/H/I   @ Mexico City              ## 1A 
 Wed Jul 1 
   (80) 12:00 UTC-4  1L v 3E/H/I/J/K   @ Atlanta
@@ -31,7 +31,7 @@ Thu Jul 2
 Fri Jul 3 
   (86) 18:00 UTC-4  1J v 2H           @ Miami (Miami Gardens)
   (87) 20:30 UTC-5  1K v 3D/E/I/J/L   @ Kansas City
-  (88) 13:00 UTC-5  2D v 2G           @ Dallas (Arlington)
+  (88) 13:00 UTC-5  Australia v 2G   @ Dallas (Arlington)   ## 2D
 
 
 ▪ Round of 16 


### PR DESCRIPTION
Groups D, E and F have finished, so this resolves the now-known Round-of-32 participants

(75) 1F → Netherlands
(76) 2F → Japan
(78) 2E → Ivory Coast
(88) 2D → Australia