### PR TITLE
World Cup 2026: fill in remaining Round-of-32 teams (74, 77-88)

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -13,25 +13,25 @@
 Sun Jun 28 
   (73) 12:00 UTC-7  South Africa v Canada   @ Los Angeles (Inglewood)   ## 2A / 2B
 Mon Jun 29
-  (74) 16:30 UTC-4  Germany v 3A/B/C/D/F   @ Boston (Foxborough)      ## 1E
+  (74) 16:30 UTC-4  Germany v Paraguay   @ Boston (Foxborough)      ## 1E / 3A/B/C/D/F
   (75) 19:00 UTC-6  Netherlands v Morocco   @ Monterrey (Guadalupe)   ## 1F / 2C
   (76) 12:00 UTC-5  Brazil v Japan   @ Houston   ## 1C / 2F
 Tue Jun 30 
-  (77) 17:00 UTC-4  1I v 3C/D/F/G/H   @ New York/New Jersey (East Rutherford) 
-  (78) 12:00 UTC-5  Ivory Coast v 2I   @ Dallas (Arlington)   ## 2E
-  (79) 19:00 UTC-6  Mexico v 3C/E/F/H/I   @ Mexico City              ## 1A 
+  (77) 17:00 UTC-4  France v Sweden   @ New York/New Jersey (East Rutherford)   ## 1I / 3C/D/F/G/H
+  (78) 12:00 UTC-5  Ivory Coast v Norway   @ Dallas (Arlington)   ## 2E / 2I
+  (79) 19:00 UTC-6  Mexico v Ecuador   @ Mexico City              ## 1A / 3C/E/F/H/I
 Wed Jul 1 
-  (80) 12:00 UTC-4  1L v 3E/H/I/J/K   @ Atlanta
-  (81) 17:00 UTC-7  USA v 3B/E/F/I/J   @ San Francisco Bay Area (Santa Clara)       ## 1D
-  (82) 13:00 UTC-7  1G v 3A/E/H/I/J   @ Seattle
+  (80) 12:00 UTC-4  England v DR Congo   @ Atlanta   ## 1L / 3E/H/I/J/K
+  (81) 17:00 UTC-7  USA v Bosnia & Herzegovina   @ San Francisco Bay Area (Santa Clara)       ## 1D / 3B/E/F/I/J
+  (82) 13:00 UTC-7  Belgium v Senegal   @ Seattle   ## 1G / 3A/E/H/I/J
 Thu Jul 2 
-  (83) 19:00 UTC-4  2K v 2L           @ Toronto 
-  (84) 12:00 UTC-7  1H v 2J           @ Los Angeles (Inglewood)
-  (85) 20:00 UTC-7  Switzerland v 3E/F/G/I/J   @ Vancouver   ## 1B
+  (83) 19:00 UTC-4  Portugal v Croatia   @ Toronto   ## 2K / 2L
+  (84) 12:00 UTC-7  Spain v Austria   @ Los Angeles (Inglewood)   ## 1H / 2J
+  (85) 20:00 UTC-7  Switzerland v Algeria   @ Vancouver   ## 1B / 3E/F/G/I/J
 Fri Jul 3 
-  (86) 18:00 UTC-4  1J v 2H           @ Miami (Miami Gardens)
-  (87) 20:30 UTC-5  1K v 3D/E/I/J/L   @ Kansas City
-  (88) 13:00 UTC-5  Australia v 2G   @ Dallas (Arlington)   ## 2D
+  (86) 18:00 UTC-4  Argentina v Cape Verde   @ Miami (Miami Gardens)   ## 1J / 2H
+  (87) 20:30 UTC-5  Colombia v Ghana   @ Kansas City   ## 1K / 3D/E/I/J/L
+  (88) 13:00 UTC-5  Australia v Egypt   @ Dallas (Arlington)   ## 2D / 2G
 
 
 ▪ Round of 16 


### PR DESCRIPTION
All 12 groups have finished, so this resolves the remaining now-known Round-of-32 participants

(74) 3A/B/C/D/F → Paraguay
(77) 1I / 3C/D/F/G/H → France v Sweden
(78) 2I → Norway
(79) 3C/E/F/H/I → Ecuador
(80) 1L / 3E/H/I/J/K → England v DR Congo
(81) 3B/E/F/I/J → Bosnia & Herzegovina
(82) 1G / 3A/E/H/I/J → Belgium v Senegal
(83) 2K / 2L → Portugal v Croatia
(84) 1H / 2J → Spain v Austria
(85) 3E/F/G/I/J → Algeria
(86) 1J / 2H → Argentina v Cape Verde
(87) 1K / 3D/E/I/J/L → Colombia v Ghana
(88) 2G → Egypt