### PR TITLE
World Cup 2026: fill in Round-of-16 team (90)

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -38,7 +38,7 @@ Fri Jul 3
 ▪ Round of 16 
 Sat Jul 4 
   (89) 17:00 UTC-4  W74 v W77   @ Philadelphia 
-  (90) 12:00 UTC-5  W73 v W75   @ Houston 
+  (90) 12:00 UTC-5  Canada v W75   @ Houston   ## W73
 Sun Jul 5 
   (91) 16:00 UTC-4  W76 v W78   @ New York/New Jersey (East Rutherford) 
   (92) 18:00 UTC-6  W79 v W80   @ Mexico City


### PR DESCRIPTION
Canada beat South Africa in match (73), so the Round-of-16 fixture in Houston now has a known participant

(90) W73 → Canada