### PR TITLE
Update Round of 16 match 89: Paraguay v France

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -46,7 +46,7 @@ Fri Jul 3
 
 ▪ Round of 16 
 Sat Jul 4 
-  (89) 17:00 UTC-4  W74 v W77   @ Philadelphia 
+  (89) 17:00 UTC-4  Paraguay v France   @ Philadelphia 
   (90) 12:00 UTC-5  Canada v W75   @ Houston   ## W73
 Sun Jul 5 
   (91) 16:00 UTC-4  W76 v W78   @ New York/New Jersey (East Rutherford) 


### PR DESCRIPTION
Paraguay 1-1 Germany (4-3 pens) - match 74
   France 3-0 Sweden - match 77
   Source: ESPN, FIFA.com official match centre