### PR TITLE
World Cup 2026: fill in Round-of-16 teams (89, 90, 91)

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -46,10 +46,10 @@ Fri Jul 3
 
 ▪ Round of 16 
 Sat Jul 4 
-  (89) 17:00 UTC-4  W74 v W77   @ Philadelphia 
-  (90) 12:00 UTC-5  Canada v W75   @ Houston   ## W73
+  (89) 17:00 UTC-4  Paraguay v France   @ Philadelphia   ## W74 / W77
+  (90) 12:00 UTC-5  Canada v Morocco   @ Houston   ## W73 / W75
 Sun Jul 5 
-  (91) 16:00 UTC-4  W76 v W78   @ New York/New Jersey (East Rutherford) 
+  (91) 16:00 UTC-4  Brazil v Norway   @ New York/New Jersey (East Rutherford)   ## W76 / W78
   (92) 18:00 UTC-6  W79 v W80   @ Mexico City
 Mon Jul 6 
   (93) 14:00 UTC-5  W83 v W84   @ Dallas (Arlington) 


### PR DESCRIPTION
Matches 74-78 have finished, so this resolves the now-known Round-of-16 participants

(89) W74 v W77 → Paraguay v France
(90) W75 → Morocco
(91) W76 v W78 → Brazil v Norway