### PR TITLE
World Cup 2026: fill in Round-of-16 team (92)

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -51,7 +51,7 @@ Sat Jul 4
   (90) 12:00 UTC-5  Canada v Morocco   @ Houston   ## W73 / W75
 Sun Jul 5 
   (91) 16:00 UTC-4  Brazil v Norway   @ New York/New Jersey (East Rutherford)   ## W76 / W78
-  (92) 18:00 UTC-6  W79 v W80   @ Mexico City
+  (92) 18:00 UTC-6  Mexico v W80   @ Mexico City   ## W79
 Mon Jul 6 
   (93) 14:00 UTC-5  W83 v W84   @ Dallas (Arlington) 
   (94) 17:00 UTC-7  W81 v W82   @ Seattle 


### PR DESCRIPTION
Mexico finished top of their Round-of-32 tie (Mexico 2-0 Ecuador), so this resolves the now-known Round-of-16 participant in match 92

(92) W79 → Mexico