### PR TITLE
World Cup 2026: fill in Round-of-16 teams (92, 94)

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -56,10 +56,10 @@ Sat Jul 4
   (90) 12:00 UTC-5  Canada v Morocco   @ Houston   ## W73 / W75
 Sun Jul 5 
   (91) 16:00 UTC-4  Brazil v Norway   @ New York/New Jersey (East Rutherford)   ## W76 / W78
-  (92) 18:00 UTC-6  Mexico v W80   @ Mexico City   ## W79
+  (92) 18:00 UTC-6  Mexico v England   @ Mexico City   ## W79 / W80
 Mon Jul 6 
   (93) 14:00 UTC-5  W83 v W84   @ Dallas (Arlington) 
-  (94) 17:00 UTC-7  W81 v W82   @ Seattle 
+  (94) 17:00 UTC-7  USA v Belgium   @ Seattle   ## W81 / W82
 Tue Jul 7 
   (95) 12:00 UTC-4  W86 v W88   @ Atlanta
   (96) 13:00 UTC-7  W85 v W87   @ Vancouver


### PR DESCRIPTION
Round-of-32 matches 80, 81 and 82 have finished, so this resolves the now-known Round-of-16 participants

(92) W80 → England
(94) W81 → USA
(94) W82 → Belgium