### PR TITLE
World Cup 2026: fill in semi-final result teams (103, 104)

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -104,10 +104,10 @@ Wed Jul 15
 
 ▪ Match for third place   
 Sat Jul 18 
-  (103) 17:00 UTC-4    L101 v L102    @ Miami (Miami Gardens)
+  (103) 17:00 UTC-4    France v L102    @ Miami (Miami Gardens)   ## L101
 
 ▪ Final
 Sun Jul 19 
-  (104) 15:00 UTC-4    W101 v W102    @ New York/New Jersey (East Rutherford)
+  (104) 15:00 UTC-4    Spain v W102    @ New York/New Jersey (East Rutherford)   ## W101
 
 


### PR DESCRIPTION
The France v Spain semi-final has finished, so this resolves the now-known third-place and final participants

(103) L101 -> France
(104) W101 -> Spain