### PR TITLE
Update World Cup 2026 match results and details (Final)

### DIFF
--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -111,6 +111,5 @@ Sat Jul 18
 
 ▪ Final
 Sun Jul 19 
-  (104) 15:00 UTC-4    Spain v Argentina    @ New York/New Jersey (East Rutherford)   ## W101 / W102
-
-
+  (104) 15:00 UTC-4    Spain 1-0 (0-0) Argentina    @ New York/New Jersey (East Rutherford)   ## W101 / W102
+                    (Ferran Torres 106')

--- a/2026--usa/cup_finals.txt
+++ b/2026--usa/cup_finals.txt
@@ -111,5 +111,5 @@ Sat Jul 18
 
 ▪ Final
 Sun Jul 19 
-  (104) 15:00 UTC-4    Spain 1-0 (0-0) Argentina    @ New York/New Jersey (East Rutherford)   ## W101 / W102
+  (104) 15:00 UTC-4  Spain 1-0 a.e.t. (0-0, 0-0) Argentina    @ New York/New Jersey (East Rutherford)   ## W101 / W102
                     (Ferran Torres 106')


### PR DESCRIPTION
Spain vs Argentina - 1:0 with Ferran Torres as 106'